### PR TITLE
Fixed naming of LexerSate -> LexerState

### DIFF
--- a/src/Tomlyn/Parsing/ITokenProvider.cs
+++ b/src/Tomlyn/Parsing/ITokenProvider.cs
@@ -16,7 +16,7 @@ namespace Tomlyn.Parsing
 
         TSourceView Source { get; }
 
-        LexerSate State { get; set; }
+        LexerState State { get; set; }
 
         bool MoveNext();
 

--- a/src/Tomlyn/Parsing/Lexer.cs
+++ b/src/Tomlyn/Parsing/Lexer.cs
@@ -65,7 +65,7 @@ namespace Tomlyn.Parsing
                 return false;
             }
 
-            if (State == LexerSate.Key)
+            if (State == LexerState.Key)
             {
                 NextTokenForKey();
             }
@@ -78,7 +78,7 @@ namespace Tomlyn.Parsing
 
         public SyntaxTokenValue Token => _token;
 
-        public LexerSate State { get; set; }
+        public LexerState State { get; set; }
 
         private TextPosition _position => _current.Position;
 

--- a/src/Tomlyn/Parsing/LexerState.cs
+++ b/src/Tomlyn/Parsing/LexerState.cs
@@ -3,7 +3,7 @@
 // See license.txt file in the project root for full license information.
 namespace Tomlyn.Parsing
 {
-    internal enum LexerSate
+    internal enum LexerState
     {
         Key,
 

--- a/src/Tomlyn/Parsing/Parser.cs
+++ b/src/Tomlyn/Parsing/Parser.cs
@@ -143,7 +143,7 @@ namespace Tomlyn.Parsing
                 else
                 {
                     // Switch the lexer to value parser
-                    _lexer.State = LexerSate.Value;
+                    _lexer.State = LexerState.Value;
                     try
                     {
                         keyValueSyntax.EqualToken = EatToken();
@@ -151,7 +151,7 @@ namespace Tomlyn.Parsing
                     }
                     finally
                     {
-                        _lexer.State = LexerSate.Key;
+                        _lexer.State = LexerState.Key;
                     }
 
                     if (expectEndOfLine && _token.Kind != TokenKind.Eof)
@@ -361,7 +361,7 @@ namespace Tomlyn.Parsing
             var inlineTable = Open<InlineTableSyntax>();
 
             var previousState = _lexer.State;
-            _lexer.State = LexerSate.Key;
+            _lexer.State = LexerState.Key;
             var previousLine = _hideNewLine;
             _hideNewLine = false;
             inlineTable.OpenBrace = EatToken(TokenKind.OpenBrace);


### PR DESCRIPTION
I noticed while reading the source code that there was a typo in the `LexerSate` class (it should be `LexerState` right).

Great work on this!