### PR TITLE
Support for Unity package installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ artifacts/
 *_p.c
 *_i.h
 *.ilk
-*.meta
 *.obj
 *.pch
 *.pdb

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ext/toml-test"]
 	path = ext/toml-test
-	url = https://github.com/xoofx/toml-test.git
+	url = https://github.com/sh42913/toml-test.git

--- a/appveyor.yml.meta
+++ b/appveyor.yml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2abd0d36ab5c4404ea675cbf3a18cbdf
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/changelog.md.meta
+++ b/changelog.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 89adbf5369058544bbb0ca28645846c7
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ext.meta
+++ b/ext.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 390f41fbd830c58488db22717e2802ac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ext/toml-test.meta
+++ b/ext/toml-test.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 97b9788bcd6dd5a4691ad704a8001fa0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/img.meta
+++ b/img.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 67228fe33f193de43b68f46752845377
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/img/logo.png.meta
+++ b/img/logo.png.meta
@@ -1,0 +1,91 @@
+fileFormatVersion: 2
+guid: fc44717e87b36074f94b52dbc857443b
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 10
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/license.txt.meta
+++ b/license.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e987646dc6e6d5644b21db1d62e0b814
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "com.xfoox.tomlyn",
+  "author": "Alexandre Mutel",
+  "displayName": "Tomlyn",
+  "description": "Tomlyn is a TOML parser, validator and authoring library for .NET Framework and .NET Core",
+  "version": "0.1.1",
+  "keywords": [
+    "TOML",
+    "Parser",
+    "Validator"
+  ],
+  "type": "tool"
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bb5d45e5586446b4cbc4222d95dac818
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,13 @@ Console.WriteLine(doc);
 // "key with space" = 2
 ```
 
+## Unity package
+This repository can be installed as Unity package directly from git URL. You need to add new line to `Packages/manifest.json` to `dependencies` section:
+```
+"com.xfoox.tomlyn": "https://github.com/sh42913/Tomlyn.git#unity-support",
+```
+Since Unity 2019.3 git URL can be added directly in Package Manager.
+
 ## License
 
 This software is released under the [BSD-Clause 2 license](https://opensource.org/licenses/BSD-2-Clause). 

--- a/readme.md.meta
+++ b/readme.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 39c0810fa2580e045bc9a020044622c6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src.meta
+++ b/src.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e8b89de392af58347843c520f893a164
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.Tests.meta
+++ b/src/Tomlyn.Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52466c61494ff46439afce914ece9039
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.Tests/AssertHelper.cs.meta
+++ b/src/Tomlyn.Tests/AssertHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5052eaf0ef74f574dae64ab7cffdc1bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.Tests/BasicTests.cs.meta
+++ b/src/Tomlyn.Tests/BasicTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bda4b8f5ffa3fa547b268870d82952e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.Tests/ModelHelper.cs.meta
+++ b/src/Tomlyn.Tests/ModelHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b00eb2c4ff38bf3488c7a7b6708c40e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.Tests/ModelTests.cs.meta
+++ b/src/Tomlyn.Tests/ModelTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 576046078f2d890429bd66a1ed2c4a2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.Tests/StandardTests.cs.meta
+++ b/src/Tomlyn.Tests/StandardTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b66ae6fbaece4c840820de082371d5cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.Tests/SyntaxTests.cs.meta
+++ b/src/Tomlyn.Tests/SyntaxTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5fc5f7a291c6f6242922de64f6b939c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.Tests/Tomlyn.Tests.csproj.meta
+++ b/src/Tomlyn.Tests/Tomlyn.Tests.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 38988742ee9fe4743a978f5f6d0d4622
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.Tests/ValidatorTests.cs.meta
+++ b/src/Tomlyn.Tests/ValidatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9da73287bc910c643be6083d873e6b61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.meta
+++ b/src/Tomlyn.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2065c505dc44f1c439f0a8aa51335661
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.sln.DotSettings.meta
+++ b/src/Tomlyn.sln.DotSettings.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2931aea13f05d4e408226cc338b92cec
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn.sln.meta
+++ b/src/Tomlyn.sln.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 74390186f31df2e4ab5c3e3cdf644689
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Collections.meta
+++ b/src/Tomlyn/Collections.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 34144922e1075254d8723e8c7409bc31
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Collections/Iterator.cs.meta
+++ b/src/Tomlyn/Collections/Iterator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2449b494d9d76245b163d1a1b9e11ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Helpers.meta
+++ b/src/Tomlyn/Helpers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c80e41fe90d6d854a9e2f509ad65915b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Helpers/DateTimeRFC3339.cs.meta
+++ b/src/Tomlyn/Helpers/DateTimeRFC3339.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcaa7037a89e39f41a536f49b41caf7d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Helpers/ThrowHelper.cs.meta
+++ b/src/Tomlyn/Helpers/ThrowHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 572afbad05954b34a85cb4866f568032
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model.meta
+++ b/src/Tomlyn/Model.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 734ade8097910de4ab80ff411508a3da
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/ObjectKind.cs.meta
+++ b/src/Tomlyn/Model/ObjectKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba9a75016060fd641b2a1973af03d5dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/SyntaxTransform.cs.meta
+++ b/src/Tomlyn/Model/SyntaxTransform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ee8bb10dbc8e6e45a486999b32f0487
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/TomlArray.cs.meta
+++ b/src/Tomlyn/Model/TomlArray.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d0d70346bd35e342b7c595278c587f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/TomlBoolean.cs.meta
+++ b/src/Tomlyn/Model/TomlBoolean.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e1fb441d1f105d44913c8f37e764464
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/TomlDateTime.cs.meta
+++ b/src/Tomlyn/Model/TomlDateTime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7fd5d7a669a0a974fb3f5a81168df39b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/TomlFloat.cs.meta
+++ b/src/Tomlyn/Model/TomlFloat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c3ac69fcb6640941a545ffefbef12d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/TomlInteger.cs.meta
+++ b/src/Tomlyn/Model/TomlInteger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f65206f116b44c4bbf0e166596462a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/TomlObject.cs.meta
+++ b/src/Tomlyn/Model/TomlObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af6dec34a97efa34dad4ad89155b437d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/TomlString.cs.meta
+++ b/src/Tomlyn/Model/TomlString.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 058ee9f9561c5cc4fb71b35fec0256f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/TomlTable.cs.meta
+++ b/src/Tomlyn/Model/TomlTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f2c60560c7cf4244b981db3805992c0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/TomlTableArray.cs.meta
+++ b/src/Tomlyn/Model/TomlTableArray.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9614d98f483a5e48a8dcc56b29cea3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Model/TomlValue.cs.meta
+++ b/src/Tomlyn/Model/TomlValue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69633b5bcf1cc2c4f983da208b21955d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Parsing.meta
+++ b/src/Tomlyn/Parsing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 35c5940421ab89048930acc097a7b60a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Parsing/ITokenProvider.cs.meta
+++ b/src/Tomlyn/Parsing/ITokenProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 841543ac2e8078d4a841d5830072e689
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Parsing/Lexer.cs.meta
+++ b/src/Tomlyn/Parsing/Lexer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7307419053ea03c44918c059e82811df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Parsing/LexerState.cs.meta
+++ b/src/Tomlyn/Parsing/LexerState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 89a57a6d85c605244aa38465d0c70f45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Parsing/Parser.cs.meta
+++ b/src/Tomlyn/Parsing/Parser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6383799b1c1df14489310ada96e59ddd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Parsing/SyntaxTokenValue.cs.meta
+++ b/src/Tomlyn/Parsing/SyntaxTokenValue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5c92fc8e0f453e4ba3a5ed015425d27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax.meta
+++ b/src/Tomlyn/Syntax.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5a6ec0a5961d03f4f91fde73e3f6c9f8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/ArrayItemSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/ArrayItemSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dcd459cd98f51664bb50cd81dd0a9609
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/ArraySyntax.cs.meta
+++ b/src/Tomlyn/Syntax/ArraySyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fe42ed06120e664ba88f378472dfe9e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/BareKeyOrStringValueSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/BareKeyOrStringValueSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6aa198d318ec8ef40b06e8e0030a7d0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/BareKeySyntax.cs.meta
+++ b/src/Tomlyn/Syntax/BareKeySyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8677b9de0afa7a24987116bf1f00051d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/BooleanValueSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/BooleanValueSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e611cc4243215004388df821735b5e94
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/DateTimeValueSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/DateTimeValueSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a799a2ae266ecb145b53e44690d6725e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/DiagnosticMessage.cs.meta
+++ b/src/Tomlyn/Syntax/DiagnosticMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c34e8d187f417b44caa49842e4f3d799
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/DiagnosticMessageKind.cs.meta
+++ b/src/Tomlyn/Syntax/DiagnosticMessageKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8066b47216a2084faabcfcab72ede2f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/DiagnosticsBag.cs.meta
+++ b/src/Tomlyn/Syntax/DiagnosticsBag.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97df2be814e1b7c46aa52c8351dcbee8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/DocumentSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/DocumentSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf330e31c55cf2144bc1901a9c946be4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/DottedKeyItemSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/DottedKeyItemSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1446e40136fca1f41ac8822973d3ed4e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/FloatValueSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/FloatValueSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8672a839cb8a643439a933f492623bc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/InlineTableItemSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/InlineTableItemSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 754e42c2ea01ae3458faba6fb34d294e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/InlineTableSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/InlineTableSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ce8871edb545e44e9b08af897ecdb5e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/IntegerValueSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/IntegerValueSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 301e7aa82a3b77f45959df5119f6f8f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/InvalidSyntaxToken.cs.meta
+++ b/src/Tomlyn/Syntax/InvalidSyntaxToken.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 989c9196c2973a74a95a77df5a37f4c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/KeySyntax.cs.meta
+++ b/src/Tomlyn/Syntax/KeySyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7232f873f90f7a64b98b4269406e3e04
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/KeyValueSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/KeyValueSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20b2149bc7a3b234e81e433a5ad28ce1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/SourceSpan.cs.meta
+++ b/src/Tomlyn/Syntax/SourceSpan.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 717295d5addd06a4389db3439e44532f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/StringValueSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/StringValueSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba93b6529339d25459369d9a23744704
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/Syntax.cd.meta
+++ b/src/Tomlyn/Syntax/Syntax.cd.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7a26a98870158fc4c81c5fb7e49881f9
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/SyntaxFactory.cs.meta
+++ b/src/Tomlyn/Syntax/SyntaxFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5351e6fbb1af7cf41936bb579cc72638
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/SyntaxKind.cs.meta
+++ b/src/Tomlyn/Syntax/SyntaxKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9bd9ab604434433409158aefb2624e58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/SyntaxList.cs.meta
+++ b/src/Tomlyn/Syntax/SyntaxList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 801dadc2237134d4bb4c563acbb9b179
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/SyntaxNode.cs.meta
+++ b/src/Tomlyn/Syntax/SyntaxNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c701e1d919bb38409ca12c3e674ba64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/SyntaxNodeBase.cs.meta
+++ b/src/Tomlyn/Syntax/SyntaxNodeBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71b7977ea5537314089356530f7fb1ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/SyntaxNodeExtensions.cs.meta
+++ b/src/Tomlyn/Syntax/SyntaxNodeExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c3aed6adb5857949bce902d47958196
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/SyntaxToken.cs.meta
+++ b/src/Tomlyn/Syntax/SyntaxToken.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e897685152f095240b49e8e7d967c133
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/SyntaxTrivia.cs.meta
+++ b/src/Tomlyn/Syntax/SyntaxTrivia.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36b10729cd9f6184ba3bb1f59ef44553
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/SyntaxValidator.cs.meta
+++ b/src/Tomlyn/Syntax/SyntaxValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10322a131bf17b64dbb99fdae3093339
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/SyntaxVisitor.cs.meta
+++ b/src/Tomlyn/Syntax/SyntaxVisitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9be2bc588067bef40b9c4075457483eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/TableArraySyntax.cs.meta
+++ b/src/Tomlyn/Syntax/TableArraySyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06f78bec7b63bd94195f422b6fe7475f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/TableSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/TableSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e7ca776db244d1428daf11ea98c1a9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/TableSyntaxBase.cs.meta
+++ b/src/Tomlyn/Syntax/TableSyntaxBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fce752bf5f1dced47ba8ddd471287407
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/TextPosition.cs.meta
+++ b/src/Tomlyn/Syntax/TextPosition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0359f7c74db77fa4484d6a6e4cf6636e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/TokenKind.cs.meta
+++ b/src/Tomlyn/Syntax/TokenKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f550769a66230434fab4c678fa3b0406
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/TokenKindExtensions.cs.meta
+++ b/src/Tomlyn/Syntax/TokenKindExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 835879916652bdf42acb128c4a746f57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Syntax/ValueSyntax.cs.meta
+++ b/src/Tomlyn/Syntax/ValueSyntax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efebea4b5e52a9d4397fe02552a66806
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Text.meta
+++ b/src/Tomlyn/Text.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bbde6a948482c1547aaa38a94a5019b0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Text/CharHelper.cs.meta
+++ b/src/Tomlyn/Text/CharHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3af7e864e9a1b974daf853fbc270df78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Text/CharReaderException.cs.meta
+++ b/src/Tomlyn/Text/CharReaderException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69e5a8bc297b24f449931562ef27b01f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Text/CharacterIterator.cs.meta
+++ b/src/Tomlyn/Text/CharacterIterator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62d912536b107a04b881251350a7beab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Text/ISourceView.cs.meta
+++ b/src/Tomlyn/Text/ISourceView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0929338be2fa3f640bab8a3b7be9117b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Text/IStringView.cs.meta
+++ b/src/Tomlyn/Text/IStringView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da8fd09f519db044680e330a720714c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Text/StringCharacterIterator.cs.meta
+++ b/src/Tomlyn/Text/StringCharacterIterator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4a9a944bccee7a41b7fac78ab41501e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Text/StringCharacterUtf8Iterator.cs.meta
+++ b/src/Tomlyn/Text/StringCharacterUtf8Iterator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b49bd56eca91214ebfad89a5afa2f75
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Text/StringSourceView.cs.meta
+++ b/src/Tomlyn/Text/StringSourceView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfcc58e3e20eaef48b10a54372daba05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Text/StringUtf8SourceView.cs.meta
+++ b/src/Tomlyn/Text/StringUtf8SourceView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5248db1253ac75d45be2e9f06e0301aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Text/char32.cs.meta
+++ b/src/Tomlyn/Text/char32.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: be4623b762a967d45b9a9cf86e06221f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Toml.cs.meta
+++ b/src/Tomlyn/Toml.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba5429e6b68a8424883137ec5e9e1aa4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/TomlParserOptions.cs.meta
+++ b/src/Tomlyn/TomlParserOptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: badb7f200948ed84f821ab3a773a943e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Tomlyn.asmdef
+++ b/src/Tomlyn/Tomlyn.asmdef
@@ -1,0 +1,13 @@
+{
+    "name": "Tomlyn",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": true
+}

--- a/src/Tomlyn/Tomlyn.asmdef.meta
+++ b/src/Tomlyn/Tomlyn.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 24e88b17316fb674a9527dfaaa8e401c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/Tomlyn.csproj.meta
+++ b/src/Tomlyn/Tomlyn.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 843b1f2167a5d2e43bf4f321888675f4
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Tomlyn/key.snk.meta
+++ b/src/Tomlyn/key.snk.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2967a34e83a43b84192fe3cfe827f417
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I've added ability to install Tomlyn as package for Unity engine. Sadly, Unity needs for a lot of .meta files, so i've removed .meta from .gitignore.

You need to make some changes before merging:
- Approve my PR with .meta files in toml-test repo
- Revert submodule link to `https://github.com/xoofx/toml-test.git` and update submodule
- Update git-url in Readme to `https://github.com/xoofx/Tomlyn.git`