### PR TITLE
Fix global.json

### DIFF
--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0",
+        "version": "5.0.402",
         "rollForward": "latestMinor",
         "allowPrerelease": false
     }


### PR DESCRIPTION
The SDK version must have major.minor.patch else it doesn't work as expected (i.e. always use the latest available SDK, completely ignoring the `global.json` settings).

- With with following .NET SDKs installed:

```
2.1.818 [/usr/local/share/dotnet/sdk]
3.1.414 [/usr/local/share/dotnet/sdk]
5.0.402 [/usr/local/share/dotnet/sdk]
6.0.100-rc.2.21505.57 [/usr/local/share/dotnet/sdk]
```

- With "rollForward": "latestMinor"
  - With "version": "5.0" in global.json  
    ❌ `dotnet --version` returns 6.0.100-rc.2.21505.57
  - With "version": "5.0.300" in global.json  
    ✅ `dotnet --version` returns 5.0.402


That's a lot of words to say that you can't use `5.0` but must use `5.0.402`.