### PR TITLE
Improve error message when PropertyName is not found in properties, but the default conversion of property_name is

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -62,7 +62,7 @@ The mapping comes with a few requirements and is highly customizable:
   - Can ignore properties via attributes (`JsonIgnore`, `DataMemberIgnore`). These attributes can be configured in `TomlModelOptions.AttributeListForIgnore`
   - By default property names are lowered and split by `_` by PascalCase letters
     - For example: `ThisIsAnExample` becomes `this_is_an_example`
-    - This behavior can be change by passing a `TomlModelOptions` and specifying the `TomlModelOptions.GetPropertyName` delegate.
+    - This behavior can be changed by passing a `TomlModelOptions` and specifying the `TomlModelOptions.GetPropertyName` delegate.
     - If the property contains a special attribute (e.g `JsonPropertyName`, `DataMember`), it will use this name instead. You can control the list of attributes in `TomlModelOptions.AttributeListForGetName`.
 - Requires class types to have a parameter-less constructor.
 - Supports all C# primitive types, `string`, `DateTime`, `DateTimeOffset` and `TomlDateTime`.

--- a/src/Tomlyn/Model/Accessors/StandardObjectDynamicAccessor.cs
+++ b/src/Tomlyn/Model/Accessors/StandardObjectDynamicAccessor.cs
@@ -155,9 +155,10 @@ internal class StandardObjectDynamicAccessor : ObjectDynamicAccessor
             return true;
         }
         var snakeCasedName = TomlModelOptions.PascalToSnakeCase(name);
-        if (_props.TryGetValue(snakeCasedName, out var _))
+        if (_props.ContainsKey(snakeCasedName))
         {
             Context.Diagnostics.Error(span, $"The property {name} was not found, but {snakeCasedName} was. By default property names are lowered and split by _ by PascalCase letters. This behavior can be changed by passing a TomlModelOptions and specifying the TomlModelOptions.GetPropertyName delegate.");
+            return false;
         }
         Context.Diagnostics.Error(span, $"The property {name} was not found on object type {TargetType.FullName}");
         return false;

--- a/src/Tomlyn/Model/Accessors/StandardObjectDynamicAccessor.cs
+++ b/src/Tomlyn/Model/Accessors/StandardObjectDynamicAccessor.cs
@@ -154,6 +154,11 @@ internal class StandardObjectDynamicAccessor : ObjectDynamicAccessor
             propertyType = prop.PropertyType;
             return true;
         }
+        var snakeCasedName = TomlModelOptions.PascalToSnakeCase(name);
+        if (_props.TryGetValue(snakeCasedName, out var _))
+        {
+            Context.Diagnostics.Error(span, $"The property {name} was not found, but {snakeCasedName} was. By default property names are lowered and split by _ by PascalCase letters. This behavior can be changed by passing a TomlModelOptions and specifying the TomlModelOptions.GetPropertyName delegate.");
+        }
         Context.Diagnostics.Error(span, $"The property {name} was not found on object type {TargetType.FullName}");
         return false;
     }

--- a/src/Tomlyn/TomlModelOptions.cs
+++ b/src/Tomlyn/TomlModelOptions.cs
@@ -95,8 +95,11 @@ public class TomlModelOptions
             }
         }
 
-        name ??= prop.Name;
+        return PascalToSnakeCase(name ?? prop.Name);
+    }
 
+    internal static string PascalToSnakeCase(string name)
+    {
         var builder = new StringBuilder();
         var pc = (char)0;
         foreach (var c in name)


### PR DESCRIPTION
I was trying out the custom model mapping, but I didn't read the documentation about how names are by default assumed to be snake case in the TOML. 

I had a model with something like `MyProperty` and had the same name in the TOML file. The error message confused me and lead me to believe that I had done something to make your reflection code not pick up the property, when actually it was just that I had not read the documentation. 🤦

I think that this new error message might help new users like myself, but I understand if this is not wanted and the real answer is to read the docs _before_ use 🙂  