### PR TITLE
allow windows (crlf) newlines in IsSafeStringLiteralMulti

### DIFF
--- a/src/Tomlyn.Tests/SerializationTests.cs
+++ b/src/Tomlyn.Tests/SerializationTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license. 
+// See license.txt file in the project root for full license information.
+
+using NUnit.Framework;
+using Tomlyn.Model;
+
+namespace Tomlyn.Tests
+{
+    public class SerializationTests
+    {
+        [Test]
+        public void TestCrlfInMultilineString()
+        {
+            var model = new TomlTable
+            {
+                PropertiesMetadata = new TomlPropertiesMetadata()
+            };
+            model.PropertiesMetadata.SetProperty("property", new TomlPropertyMetadata
+            {
+                DisplayKind = TomlPropertyDisplayKind.StringLiteralMulti
+            });
+
+            model["property"] = "string\r\nwith\r\nnewlines";
+
+            Assert.AreEqual("property = '''string\r\nwith\r\nnewlines'''\r\n", Toml.FromModel(model));
+        }
+    }
+}

--- a/src/Tomlyn/Helpers/TomlFormatHelper.cs
+++ b/src/Tomlyn/Helpers/TomlFormatHelper.cs
@@ -227,7 +227,7 @@ public class TomlFormatHelper
         {
             var c = text[i];
             // new line are permitted
-            if ((c == '\r' && i + 1 < text.Length && text[i + 1] == 'n') || c == '\n')
+            if ((c == '\r' && i + 1 < text.Length && text[i + 1] == '\n') || c == '\n')
             {
                 continue;
             }


### PR DESCRIPTION
closes https://github.com/xoofx/Tomlyn/issues/25

I wasn't sure about how to write the test, but it seems to check the right thing. Happy to change that if you want