### PR TITLE
Normalize line endings for tests which are sensitive to line ending

### DIFF
--- a/src/Tomlyn.Tests/ModelTests/ReflectionModelTests.cs
+++ b/src/Tomlyn.Tests/ModelTests/ReflectionModelTests.cs
@@ -361,7 +361,8 @@ key = 1
 [[array]] # a comment after a table array
 key2 = 3
 # This is a comment after a key
-";
+".ReplaceLineEndings();
+
             StandardTests.DisplayHeader("input");
             Console.WriteLine(input);
             var model = Toml.ToModel(input);

--- a/src/Tomlyn.Tests/SerializationTests.cs
+++ b/src/Tomlyn.Tests/SerializationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the BSD-Clause 2 license. 
 // See license.txt file in the project root for full license information.
 
+using System;
 using NUnit.Framework;
 using Tomlyn.Model;
 
@@ -23,7 +24,7 @@ namespace Tomlyn.Tests
 
             model["property"] = "string\r\nwith\r\nnewlines";
 
-            Assert.AreEqual("property = '''string\r\nwith\r\nnewlines'''\r\n", Toml.FromModel(model));
+            Assert.AreEqual("property = '''string\r\nwith\r\nnewlines'''" + Environment.NewLine, Toml.FromModel(model));
         }
     }
 }

--- a/src/Tomlyn.Tests/TomlTests.cs
+++ b/src/Tomlyn.Tests/TomlTests.cs
@@ -34,7 +34,8 @@ key = 1 # This is another comment
 test.sub.key = ""yes""
 [[array]]
 hello = true
-";
+".ReplaceLineEndings("\r\n");
+
         var tokens = Toml.Parse(input).Tokens().ToList();
         var builder = new StringBuilder();
         foreach (var node in tokens)


### PR DESCRIPTION
This fixes tests that don't pass on Linux/macOS or Windows when git is configured with core.autocrlf=false