### PR TITLE
Use stable sort

### DIFF
--- a/src/Tomlyn.Tests/ModelTests/TomlTableModelTests.cs
+++ b/src/Tomlyn.Tests/ModelTests/TomlTableModelTests.cs
@@ -302,6 +302,36 @@ answer = 42
             }
         }
 
+        [Test]
+        public void TestOrdering()
+        {
+            var t = new Tomlyn.Model.TomlTable();
+            for (var i = 0; i < 17; ++i)
+            {
+                t.Add($"Test{i}", "Test");
+            }
+
+            Assert.AreEqual(
+@"Test0 = ""Test""
+Test1 = ""Test""
+Test2 = ""Test""
+Test3 = ""Test""
+Test4 = ""Test""
+Test5 = ""Test""
+Test6 = ""Test""
+Test7 = ""Test""
+Test8 = ""Test""
+Test9 = ""Test""
+Test10 = ""Test""
+Test11 = ""Test""
+Test12 = ""Test""
+Test13 = ""Test""
+Test14 = ""Test""
+Test15 = ""Test""
+Test16 = ""Test""
+", Toml.FromModel(t));
+        }
+
         private static void AssertJson(string input, string expectedJson)
         {
             var syntax = Toml.Parse(input);

--- a/src/Tomlyn/Model/ModelToTomlTransform.cs
+++ b/src/Tomlyn/Model/ModelToTomlTransform.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Linq;
 using Tomlyn.Helpers;
 using Tomlyn.Model.Accessors;
 using Tomlyn.Syntax;
@@ -199,7 +200,8 @@ internal class ModelToTomlTransform
             }
 
             // Sort primitive first
-            properties.Sort((left, right) =>
+            properties = properties.OrderBy(_ => _,
+            Comparer<KeyValuePair<string,object>>.Create((left, right) =>
             {
                 var leftValue = left.Value;
                 var rightValue = right.Value;
@@ -219,7 +221,7 @@ internal class ModelToTomlTransform
 
                 // Otherwise don't change the order if we don't have primitives
                 return 0;
-            });
+            })).ToList();
 
             // Probe inline for each key
             // If we require a key to be inlined, inline the rest


### PR DESCRIPTION
A dotnet list uses [unstable](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.sort?view=net-6.0) quick sort for sorting. This results in the Toml being output in an unordered fasion.

This change will perserve order of props especially for TomlTable.