### PR TITLE
System.InvalidCastException when transforming inline table syntax to model

### DIFF
--- a/src/Tomlyn.Tests/ModelTests/ReflectionModelTests.cs
+++ b/src/Tomlyn.Tests/ModelTests/ReflectionModelTests.cs
@@ -39,7 +39,7 @@ list = [4, 5, 6]
                 ConvertToToml = (value) => value is Uri uri ? uri.ToString() : null
             };
             var success = Toml.TryToModel<TestConfigWithUri>(text, out var result, out var diagnostics, null, options);
-            
+
             Assert.True(success);
             Assert.AreEqual(expected, result?.ServiceUri);
 
@@ -334,6 +334,52 @@ publish = false
 
 [[sub]]
 id = ""id3""";
+            var syntax = Toml.Parse(input);
+            Assert.False(syntax.HasErrors, "The document should not have any errors");
+
+            StandardTests.Dump(input, syntax, syntax.ToString());
+
+            var model = syntax.ToModel<SimpleModel>();
+
+            Assert.AreEqual("this is a name", model.Name);
+            Assert.AreEqual(new List<string>() {"a", "b", "c", "1"}, model.Values);
+            Assert.AreEqual(new List<int>() { 1 }, model.IntValues);
+            Assert.AreEqual(2, model.IntValue);
+            Assert.AreEqual(2.5, model.DoubleValue);
+            Assert.AreEqual(3, model.SubModels.Count);
+            var sub = model.SubModels[0];
+            Assert.AreEqual("id1", sub.Id);
+            Assert.True(sub.Publish);
+            sub = model.SubModels[1];
+            Assert.AreEqual("id2", sub.Id);
+            Assert.False(sub.Publish);
+            sub = model.SubModels[2];
+            Assert.AreEqual("id3", sub.Id);
+            Assert.False(sub.Publish);
+
+            model.SubModels[2].Value = 127;
+
+            var toml = Toml.FromModel(model);
+            StandardTests.DisplayHeader("toml from model");
+            Console.WriteLine(toml);
+
+            var model2 = Toml.ToModel(toml);
+            var result = (model2["sub"] as TomlTableArray)?[2]?["value"];
+            Assert.AreEqual(127, result);
+        }
+
+        [Test]
+        public void TestReflectionModelWithInlineTable()
+        {
+            var input = @"name = ""this is a name""
+values = [""a"", ""b"", ""c"", 1]
+
+int_values = 1
+int_value = 2
+double_value = 2.5
+
+sub = [ { id = ""id1"", publish = true }, { id = ""id2"", publish = false }, { id = ""id3"" } ]
+";
             var syntax = Toml.Parse(input);
             Assert.False(syntax.HasErrors, "The document should not have any errors");
 


### PR DESCRIPTION
I have added a new test: `TestReflectionModelWithInlineTable` which is basically a copy of `TestReflectionModel` but with the inline table syntax.

**TestReflectionModel**:
```toml
[[sub]]
id = "id1"
publish = true

[[sub]]
id = "id2"
publish = false

[[sub]]
id = "id3"
```

**TestReflectionModelWithInlineTable**:
```toml
sub = [ { id = "id1", publish = true }, { id = "id2", publish = false }, { id = "id3" } ]
```

With the inline table syntax, this exception is thrown:
> System.InvalidCastException : Unable to cast object of type 'Tomlyn.Model.Accessors.ListDynamicAccessor' to type 'Tomlyn.Model.Accessors.ObjectDynamicAccessor'.

At line 72 of SyntaxToModelTransform.cs:
```csharp
var objectAccessor = ((ObjectDynamicAccessor)_currentObjectAccessor!);
```

This is not an _obvious_ bug to fix (at least for me) but I chose to open a draft pull request anyway because I think this new test is a good starting point to discuss the issue.