### PR TITLE
fix dotnet 8 breakage in SlowDictionaryAccessor by getting the enumerator through IDictionary instead of IEnumerable

### DIFF
--- a/src/Tomlyn/Model/Accessors/DictionaryDynamicAccessor.cs
+++ b/src/Tomlyn/Model/Accessors/DictionaryDynamicAccessor.cs
@@ -227,8 +227,7 @@ internal class DictionaryDynamicAccessor : ObjectDynamicAccessor
 
         public override IEnumerable<KeyValuePair<string, object?>> GetElements(object dictionary)
         {
-            var it = (IEnumerable)dictionary;
-            var enumerator = (IDictionaryEnumerator)it.GetEnumerator();
+            var enumerator = ((IDictionary)dictionary).GetEnumerator();
             while (enumerator.MoveNext())
             {
 


### PR DESCRIPTION
This fixes the issue described in https://github.com/xoofx/Tomlyn/issues/76

A optimization in dotnet 8 means that we can't assume that the `IEnumerable` interfaces `GetEnumerator` will be the same as the version from `IDictionary`. We know that casting to `IDictionary` will be safe because this accessor is only used when the object is `ReflectionObjectKind.Dictionary`