### PR TITLE
Add TomlPropertyDisplayKind.NoInline

### DIFF
--- a/src/Tomlyn/Model/ModelToTomlTransform.cs
+++ b/src/Tomlyn/Model/ModelToTomlTransform.cs
@@ -255,7 +255,9 @@ internal class ModelToTomlTransform
                 }
 
                 bool isLastValue = lastValue is not null && ReferenceEquals(lastValue, prop.Value);
-                var propToInline = (!isLastValue || lastInline) && propInline;
+
+                var displayKind = GetDisplayKind(prop.Key);
+                var propToInline = (!isLastValue || lastInline) && propInline && (displayKind != TomlPropertyDisplayKind.NoInline);
 
                 // If we switch from non inline to inline, ensure that the scope is here
                 if (!inline && propToInline)

--- a/src/Tomlyn/Model/TomlPropertiesMetadata.cs
+++ b/src/Tomlyn/Model/TomlPropertiesMetadata.cs
@@ -91,4 +91,5 @@ public enum TomlPropertyDisplayKind
     StringLiteralMulti,
 
     InlineTable,
+    NoInline
 }


### PR DESCRIPTION
Adds `TomlPropertyDisplayKind.NoInline` that overrides default inline logic and renders property explicitly not inlined.