### PR TITLE
Correctly handle double uppercase

### DIFF
--- a/src/Tomlyn/Helpers/TomlNamingHelper.cs
+++ b/src/Tomlyn/Helpers/TomlNamingHelper.cs
@@ -28,7 +28,7 @@ public class TomlNamingHelper
             var pc = (char)0;
             foreach (var c in name)
             {
-                if (char.IsUpper(c) && !char.IsUpper(pc) && pc != 0 && pc != '_')
+                if (char.IsUpper(c) && pc != 0 && pc != '_')
                 {
                     builder.Append('_');
                 }


### PR DESCRIPTION
Hi,

When I have a property "InneIRommet" (with double uppercase), the resulting snake case is inne_irommet. I think it should be inne_i_rommet (and so does googling it :)

Regards,
Sebastian