### PR TITLE
sourcegen: emit public constructors on generated TomlSerializerContext

### DIFF
--- a/src/Tomlyn.SourceGeneration/TomlSerializerContextGenerator.cs
+++ b/src/Tomlyn.SourceGeneration/TomlSerializerContextGenerator.cs
@@ -397,6 +397,18 @@ public sealed class TomlSerializerContextGenerator : IIncrementalGenerator
         builder.Append("    public static ").Append(model.TypeName).AppendLine(" Default { get; } = new(CreateDefaultOptions(), _generated: true);");
         builder.AppendLine();
 
+        builder.Append("    /// <summary>Initializes a new instance of the <see cref=\"").Append(model.TypeName).AppendLine("\"/> class.</summary>");
+        builder.Append("    /// <remarks>Uses the options configured by <see cref=\"global::Tomlyn.Serialization.TomlSourceGenerationOptionsAttribute\"/>, equivalent to <see cref=\"Default\"/>.</remarks>");
+        builder.AppendLine();
+        builder.Append("    public ").Append(model.TypeName).AppendLine("() : base(CreateDefaultOptions()) { }");
+        builder.AppendLine();
+
+        builder.Append("    /// <summary>Initializes a new instance of the <see cref=\"").Append(model.TypeName).AppendLine("\"/> class with the specified options.</summary>");
+        builder.Append("    /// <param name=\"options\">The options to use for serialization and deserialization.</param>");
+        builder.AppendLine();
+        builder.Append("    public ").Append(model.TypeName).AppendLine("(global::Tomlyn.TomlSerializerOptions options) : base(options) { }");
+        builder.AppendLine();
+
         EmitCreateDefaultOptions(builder, model);
 
         foreach (var type in ordered)

--- a/src/Tomlyn.Tests/NewApiSourceGenerationTests.cs
+++ b/src/Tomlyn.Tests/NewApiSourceGenerationTests.cs
@@ -609,6 +609,33 @@ public class NewApiSourceGenerationTests
     }
 
     [Test]
+    public void GeneratedContext_ParameterlessConstructor_BehavesLikeDefault()
+    {
+        var context = new TestTomlSerializerContext();
+        var person = TomlSerializer.Deserialize("name = \"Ada\"\nage = 37", context.GeneratedPerson);
+
+        Assert.That(person, Is.Not.Null);
+        Assert.That(person!.Name, Is.EqualTo("Ada"));
+        Assert.That(person.Age, Is.EqualTo(37));
+    }
+
+    [Test]
+    public void GeneratedContext_OptionsConstructor_UsesSuppliedOptions()
+    {
+        var options = new TomlSerializerOptions { PropertyNameCaseInsensitive = true };
+        var context = new TestTomlSerializerContext(options);
+
+        // The supplied options flow through to the base context (Default would be false here).
+        Assert.That(context.Options.PropertyNameCaseInsensitive, Is.True);
+
+        // ...and the options-constructed context still produces working source-generated metadata.
+        var person = TomlSerializer.Deserialize("name = \"Ada\"\nage = 37", context.GeneratedPerson);
+        Assert.That(person, Is.Not.Null);
+        Assert.That(person!.Name, Is.EqualTo("Ada"));
+        Assert.That(person.Age, Is.EqualTo(37));
+    }
+
+    [Test]
     public void GeneratedContext_CanUseCustomTypeInfoPropertyName()
     {
         var context = TestTomlSerializerContextCustomPropertyName.Default;


### PR DESCRIPTION
Fixes #129.

The source generator emitted a generated `TomlSerializerContext` with only a private `(TomlSerializerOptions, bool)` constructor (used by the static `Default`), so consumer code couldn't construct a context with custom options — `new MyContext()` / `new MyContext(options)` failed to compile (`CS1729`). This brings it in line with `System.Text.Json`'s `JsonSerializerContext`, which exposes a public parameterless constructor and an options-accepting constructor.

**Change:** in `TomlSerializerContextGenerator` (context emission), also emit:

```csharp
public MyContext() : base(CreateDefaultOptions()) { }
public MyContext(TomlSerializerOptions options) : base(options) { }
```

The existing private constructor and static `Default` are unchanged, so this is purely additive — no behavior change for current users.

**Tests:** added to `NewApiSourceGenerationTests` — construct a generated context via both new constructors, verify it serializes/deserializes correctly, and verify supplied options flow through to `Context.Options`.

**Risk:** low — additive generated API, `JsonSerializerContext` parity.
